### PR TITLE
Update forum references

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -5,9 +5,9 @@ Here are few guidelines that should help you get started.
 
 == Using GitHub issues
 
-We use GitHub issues to track bugs and enhancements. Find a bug in the source code? Want to propose new features or enhancements? You can help us by submitting an issue in our https://github.com/gravitee-io/gravitee-gateway[repository]. Before you submit your issue, search the https://github.com/gravitee-io/issues/issues[issues archive] or the https://waffle.io/gravitee-io/release[backlog]; maybe your question was already answered.
+We use GitHub issues to track bugs and enhancements. Find a bug in the source code? Want to propose new features or enhancements? You can help us by submitting an issue in our https://github.com/gravitee-io/gravitee-policy-url-rewriting[repository]. Before you submit your issue, search the https://github.com/gravitee-io/issues/issues[issues repository]; maybe your question was already answered.
 
-> Issues are only to report bugs, request enhancements, or request new features. For general questions and discussions, use the https://gitter.im/gravitee-io/gravitee-io[Gravitee.io Gitter chat].
+> Issues are only to report bugs, request enhancements, or request new features. For general questions and discussions, use the image:https://f.hubspotusercontent40.net/hubfs/7600448/gravitee-github-button.jpg["Join the community forum", link="https://community.gravitee.io?utm_source=contributing", height=20].
 
 Providing the following information will help us deal quickly with your issue :
 


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-url-rewriting/1.5.0/gravitee-policy-url-rewriting-1.5.0.zip)
  <!-- Version placeholder end -->
