### PR TITLE
Keep all values of multivalued headers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -62,7 +62,7 @@ You can use the `url-rewriting` policy to rewrite URLs from an HTTP response hea
 "url-rewriting": {
     "rewriteResponseHeaders": true,
     "rewriteResponseBody": true,
-    "fromRegex": "https?://[^\/]*\/((.*|\/*))",
+    "fromRegex": "https?://[^\/]*\/((\w*|\/*))",
     "toReplacement": "https://apis.gravitee.io/{#group[1]}"
 }
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -30,19 +30,34 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>17.2</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>
-        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.6.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.15.5</gravitee-common.version>
-        <gravitee-gateway.version>1.27.3</gravitee-gateway.version>
+        <gravitee-bom.version>3.0.8</gravitee-bom.version>
+        <gravitee-gateway-api.version>1.34.2</gravitee-gateway-api.version>
+        <gravitee-apim.version>3.18.28</gravitee-apim.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>1.27.0</gravitee-common.version>
+        <gravitee-expression-language.version>1.9.7</gravitee-expression-language.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Import bom to properly inherit all dependencies -->
+            <dependency>
+                <groupId>io.gravitee</groupId>
+                <artifactId>gravitee-bom</artifactId>
+                <version>${gravitee-bom.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Provided scope -->
@@ -68,26 +83,26 @@
         </dependency>
 
         <dependency>
+            <groupId>io.gravitee.el</groupId>
+            <artifactId>gravitee-expression-language</artifactId>
+            <version>${gravitee-expression-language.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-buffer</artifactId>
+            <version>${gravitee-apim.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- Test scope -->
-        <dependency>
-            <groupId>io.gravitee.gateway</groupId>
-            <artifactId>gravitee-gateway-buffer</artifactId>
-            <version>${gravitee-gateway.version}</version>
-            <scope>test</scope>
-        </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -95,8 +110,21 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/policy/urlrewriting/URLRewritingPolicy.java
+++ b/src/main/java/io/gravitee/policy/urlrewriting/URLRewritingPolicy.java
@@ -58,10 +58,12 @@ public class URLRewritingPolicy {
     private static final String GROUP_ATTRIBUTE = "group";
     private static final String GROUP_NAME_ATTRIBUTE = "groupName";
 
-    private URLRewritingPolicyConfiguration configuration;
+    private final URLRewritingPolicyConfiguration configuration;
+    private final Pattern configuredURLPattern;
 
     public URLRewritingPolicy(final URLRewritingPolicyConfiguration configuration) {
         this.configuration = configuration;
+        this.configuredURLPattern = Pattern.compile(configuration.getFromRegex());
     }
 
     @OnResponse
@@ -127,10 +129,9 @@ public class URLRewritingPolicy {
 
         if (value != null && !value.isEmpty()) {
             // Compile pattern
-            Pattern pattern = Pattern.compile(configuration.getFromRegex());
 
             // Apply regex capture / replacement
-            Matcher matcher = pattern.matcher(value);
+            Matcher matcher = this.configuredURLPattern.matcher(value);
             int start = 0;
 
             boolean result = matcher.find();
@@ -147,7 +148,7 @@ public class URLRewritingPolicy {
                     executionContext.getTemplateEngine().getTemplateContext().setVariable(GROUP_ATTRIBUTE, groups);
 
                     // Extract capture group by name
-                    Set<String> extractedGroupNames = getNamedGroupCandidates(pattern.pattern());
+                    Set<String> extractedGroupNames = getNamedGroupCandidates(this.configuredURLPattern.pattern());
                     Map<String, String> groupNames = extractedGroupNames
                         .stream()
                         .collect(Collectors.toMap(groupName -> groupName, matcher::group));

--- a/src/main/java/io/gravitee/policy/urlrewriting/URLRewritingPolicy.java
+++ b/src/main/java/io/gravitee/policy/urlrewriting/URLRewritingPolicy.java
@@ -29,9 +29,7 @@ import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.annotations.OnResponse;
 import io.gravitee.policy.api.annotations.OnResponseContent;
 import io.gravitee.policy.urlrewriting.configuration.URLRewritingPolicyConfiguration;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -83,7 +81,15 @@ public class URLRewritingPolicy {
     private void rewriteHeaders(HttpHeaders headers, ExecutionContext executionContext) {
         LOGGER.debug("Rewrite HTTP response headers");
 
-        headers.names().forEach(header -> headers.set(header, rewrite(headers.get(header), executionContext)));
+        Set<String> names = new HashSet<>(headers.names());
+        names.forEach(headerName -> {
+            List<String> headerValues = headers.getAll(headerName);
+            headers.remove(headerName);
+            headerValues.forEach(headerValue -> {
+                String rewrittenHeaderValue = rewrite(headerValue, executionContext);
+                headers.add(headerName, rewrittenHeaderValue);
+            });
+        });
     }
 
     @OnResponseContent

--- a/src/test/java/io/gravitee/policy/urlrewriting/URLRewritingPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/urlrewriting/URLRewritingPolicyIntegrationTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.urlrewriting;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.apim.gateway.tests.sdk.configuration.GatewayConfigurationBuilder;
+import io.gravitee.definition.model.Api;
+import io.gravitee.definition.model.ExecutionMode;
+import io.gravitee.gateway.api.http.HttpHeaderNames;
+import io.gravitee.policy.urlrewriting.configuration.URLRewritingPolicyConfiguration;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@GatewayTest
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class URLRewritingPolicyIntegrationTest extends AbstractPolicyTest<URLRewritingPolicy, URLRewritingPolicyConfiguration> {
+
+    @Override
+    protected void configureGateway(GatewayConfigurationBuilder gatewayConfigurationBuilder) {
+        super.configureGateway(gatewayConfigurationBuilder);
+        gatewayConfigurationBuilder.set("api.jupiterMode.enabled", "false");
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        api.setExecutionMode(ExecutionMode.V3);
+    }
+
+    @Test
+    @DeployApi("/apis/api.json")
+    void should_rewrite_headers(WebClient client) {
+        wiremock.stubFor(
+            post("/team")
+                .willReturn(
+                    ok("{ \"aUrl\": \"http://test.com/body\" }")
+                        .withHeader(
+                            HttpHeaderNames.SET_COOKIE,
+                            "SID=ABAN12398123NJHJZEHDK123012039301U93274923U4KADNZKN; Path=http://test.com/header1"
+                        )
+                        .withHeader(HttpHeaderNames.SET_COOKIE, "JSESSIONID=123456789; Path=https://test.com/header2")
+                )
+        );
+
+        client
+            .post("/test")
+            .rxSend()
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                assertThat(response.headers().getAll(HttpHeaderNames.SET_COOKIE))
+                    .isEqualTo(
+                        List.of(
+                            "SID=ABAN12398123NJHJZEHDK123012039301U93274923U4KADNZKN; Path=https://apis.gravitee.io/header1",
+                            "JSESSIONID=123456789; Path=https://apis.gravitee.io/header2"
+                        )
+                    );
+                return true;
+            })
+            .assertComplete()
+            .assertNoErrors();
+    }
+
+    @DeployApi("/apis/api.json")
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void should_rewrite_body(String backendResponse, String expectedBody, WebClient client) {
+        wiremock.stubFor(post("/team").willReturn(ok(backendResponse)));
+
+        client
+            .post("/test")
+            .rxSend()
+            .map(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return response.body();
+            })
+            .test()
+            .awaitDone(5, TimeUnit.SECONDS)
+            .assertValue(body -> {
+                assertThat(body).hasToString(expectedBody);
+                return true;
+            })
+            .assertComplete()
+            .assertNoErrors();
+    }
+
+    static Stream<Arguments> provideParameters() {
+        return Stream.of(
+            Arguments.of(
+                "{ \"aUrl\": \"http://test.com/body\", \"a2ndUrl\": \"http://test.com/body2\" }",
+                "{ \"aUrl\": \"https://apis.gravitee.io/body\", \"a2ndUrl\": \"https://apis.gravitee.io/body2\" }"
+            ),
+            Arguments.of(
+                "{ \"aUrl\": \"http://test.com/body\", \n \"a2ndUrl\": \"http://test.com/body2\" }",
+                "{ \"aUrl\": \"https://apis.gravitee.io/body\", \n \"a2ndUrl\": \"https://apis.gravitee.io/body2\" }"
+            ),
+            Arguments.of(
+                "{ \"aUrl\": \"http://test.com/body\", \n \"a2ndUrl\": \"http://test.com/body2\", \"a3rdUrl\": \"http://test.com/body3\", \"anotherValue\": \"test\" }",
+                "{ \"aUrl\": \"https://apis.gravitee.io/body\", \n \"a2ndUrl\": \"https://apis.gravitee.io/body2\", \"a3rdUrl\": \"https://apis.gravitee.io/body3\", \"anotherValue\": \"test\" }"
+            )
+        );
+    }
+}

--- a/src/test/java/io/gravitee/policy/urlrewriting/URLRewritingPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/urlrewriting/URLRewritingPolicyTest.java
@@ -15,14 +15,12 @@
  */
 package io.gravitee.policy.urlrewriting;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 import io.gravitee.el.TemplateEngine;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.Response;
-import io.gravitee.gateway.api.buffer.Buffer;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
 import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.gateway.api.stream.ReadWriteStream;
@@ -138,62 +136,6 @@ public class URLRewritingPolicyTest {
 
         // Check results
         Assert.assertNull(stream);
-    }
-
-    @Test
-    public void test_rewriteResponse_noRewriting() {
-        // Prepare
-        when(configuration.isRewriteResponseBody()).thenReturn(true);
-        when(configuration.getFromRegex()).thenReturn("https?://[^\\/]*\\/((.*|\\/*))");
-
-        // Execute policy
-        Buffer buffer = Buffer.buffer("{\"name\":1}");
-        ReadWriteStream stream = urlRewritingPolicy.onResponseContent(request, response, executionContext);
-        stream.write(buffer);
-        stream.end();
-
-        // Check results
-        Assert.assertNotNull(stream);
-    }
-
-    @Test
-    public void test_rewriteResponse_singleMatch() {
-        // Prepare
-        when(configuration.isRewriteResponseBody()).thenReturn(true);
-        when(configuration.getFromRegex()).thenReturn("https?://[^\\/]*\\/((.*|\\/*))");
-        when(configuration.getToReplacement()).thenReturn("https://apis.gravitee.io/{#group[1]}");
-
-        // Prepare context
-        when(executionContext.getTemplateEngine()).thenReturn(TemplateEngine.templateEngine());
-
-        // Execute policy
-        Buffer buffer = Buffer.buffer("{\"link\":\"http://localhost:8082/mypath/toto\"}");
-        ReadWriteStream stream = urlRewritingPolicy.onResponseContent(request, response, executionContext);
-        stream.write(buffer);
-        stream.end();
-
-        // Check results
-        Assert.assertNotNull(stream);
-    }
-
-    @Test
-    public void test_rewriteResponse_multipleMatches() {
-        // Prepare
-        when(configuration.isRewriteResponseBody()).thenReturn(true);
-        when(configuration.getFromRegex()).thenReturn("https?:\\/\\/[^\\/]*\\/(([a-zA-Z\\/]*|\\/*))");
-        when(configuration.getToReplacement()).thenReturn("https://apis.gravitee.io/{#group[1]}");
-
-        // Prepare context
-        when(executionContext.getTemplateEngine()).thenReturn(TemplateEngine.templateEngine());
-
-        // Execute policy
-        Buffer buffer = Buffer.buffer("{\"links\":[\"http://localhost:8082/mypath/toto\", \"http://localhost:8082/mypath/tata\"]}");
-        ReadWriteStream stream = urlRewritingPolicy.onResponseContent(request, response, executionContext);
-        stream.write(buffer);
-        stream.end();
-
-        // Check results
-        Assert.assertNotNull(stream);
     }
 
     @Test

--- a/src/test/resources/apis/api.json
+++ b/src/test/resources/apis/api.json
@@ -1,0 +1,45 @@
+{
+    "id": "api-fail-response-template",
+    "name": "my-api",
+    "gravitee": "2.0.0",
+    "proxy": {
+        "context_path": "/test",
+        "endpoints": [
+            {
+                "name": "default",
+                "target": "http://localhost:8080/team",
+                "http": {
+                    "connectTimeout": 3000,
+                    "readTimeout": 60000
+                }
+            }
+        ]
+    },
+    "flows": [
+        {
+            "name": "flow-1",
+            "methods": [],
+            "enabled": true,
+            "path-operator": {
+                "path": "/",
+                "operator": "STARTS_WITH"
+            },
+            "pre": [],
+            "post": [
+                {
+                    "name": "URL Rewriting",
+                    "description": "",
+                    "enabled": true,
+                    "policy": "url-rewriting",
+                    "configuration": {
+                        "rewriteResponseHeaders": true,
+                        "rewriteResponseBody": true,
+                        "fromRegex": "https?://[^/]*/((\\w*|/*))",
+                        "toReplacement": "https://apis.gravitee.io/{#group[1]}"
+                    }
+                }
+            ]
+        }
+    ],
+    "resources": []
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -30,7 +30,7 @@
 
     <!-- Strictly speaking, the level attribute is not necessary since -->
     <!-- the level of the root level is set to DEBUG by default.       -->
-    <root level="DEBUG">
+    <root level="ERROR">
         <appender-ref ref="STDOUT" />
     </root>
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-1906
https://github.com/gravitee-io/issues/issues/9085

**Description**

Keep all values of multivalued headers instead of keeping only the last one
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.1-APIM-1906-multivalue-headers-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-url-rewriting/1.5.1-APIM-1906-multivalue-headers-SNAPSHOT/gravitee-policy-url-rewriting-1.5.1-APIM-1906-multivalue-headers-SNAPSHOT.zip)
  <!-- Version placeholder end -->
