### PR TITLE
Update regex from documentation to handle single-line body with multiple urls

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -62,7 +62,7 @@ You can use the `url-rewriting` policy to rewrite URLs from an HTTP response hea
 "url-rewriting": {
     "rewriteResponseHeaders": true,
     "rewriteResponseBody": true,
-    "fromRegex": "https?://[^\/]*\/((\w*|\/*))",
-    "toReplacement": "https://apis.gravitee.io/{#group[1]}"
+    "fromRegex": "https?://[^\/]*\/((?>\w|\d|\-|\/|\?|\=|\&)*)",
+    "toReplacement": "https://apis.gravitee.io/{#group[0]}"
 }
 ----

--- a/src/test/java/io/gravitee/policy/urlrewriting/URLRewritingPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/urlrewriting/URLRewritingPolicyIntegrationTest.java
@@ -121,6 +121,10 @@ class URLRewritingPolicyIntegrationTest extends AbstractPolicyTest<URLRewritingP
                 "{ \"aUrl\": \"https://apis.gravitee.io/body\", \n \"a2ndUrl\": \"https://apis.gravitee.io/body2\" }"
             ),
             Arguments.of(
+                "{ \"aUrl\": \"http://test.com/body/some-path?param1=1&param2=test\", \"a2ndUrl\": \"http://test.com/body2\" }",
+                "{ \"aUrl\": \"https://apis.gravitee.io/body/some-path?param1=1&param2=test\", \"a2ndUrl\": \"https://apis.gravitee.io/body2\" }"
+            ),
+            Arguments.of(
                 "{ \"aUrl\": \"http://test.com/body\", \n \"a2ndUrl\": \"http://test.com/body2\", \"a3rdUrl\": \"http://test.com/body3\", \"anotherValue\": \"test\" }",
                 "{ \"aUrl\": \"https://apis.gravitee.io/body\", \n \"a2ndUrl\": \"https://apis.gravitee.io/body2\", \"a3rdUrl\": \"https://apis.gravitee.io/body3\", \"anotherValue\": \"test\" }"
             )

--- a/src/test/resources/apis/api.json
+++ b/src/test/resources/apis/api.json
@@ -34,8 +34,8 @@
                     "configuration": {
                         "rewriteResponseHeaders": true,
                         "rewriteResponseBody": true,
-                        "fromRegex": "https?://[^/]*/((\\w*|/*))",
-                        "toReplacement": "https://apis.gravitee.io/{#group[1]}"
+                        "fromRegex": "https?://[^\\/]*\\/((?>\\w|\\d|\\-|\\/|\\?|\\=|\\&)*)",
+                        "toReplacement": "https://apis.gravitee.io/{#group[0]}"
                     }
                 }
             ]


### PR DESCRIPTION
**Issue**

NA

**Description**

Update regex from documentation to handle single-line body with multiple URLs.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.5.2-improve-regex-from-documentation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-url-rewriting/1.5.2-improve-regex-from-documentation-SNAPSHOT/gravitee-policy-url-rewriting-1.5.2-improve-regex-from-documentation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
