### PR TITLE
fix: update policy description

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default
-*       @gravitee-io/apim @gravitee-io/archi
+*       @gravitee-io/apim

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 **Issue**
 
-https://github.com/gravitee-io/issues/issues/XXXXX
+https://gravitee.atlassian.net/browse/APIM-XXXX
 
 **Description**
 

--- a/README.adoc
+++ b/README.adoc
@@ -24,6 +24,14 @@ endif::[]
 
 You can use the `url-rewriting` policy to rewrite URLs from an HTTP response header or response body.
 
+== Compatibility with APIM
+
+|===
+| Plugin version | APIM version
+| 1.x            | All supported versions
+|===
+
+
 == Configuration
 
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <version>1.6.0</version>
 
     <name>Gravitee.io APIM - Policy - URL Rewriting</name>
-    <description>Description of the URL Rewriting Gravitee Policy</description>
+    <description>Rewrite URLs from an HTTP response header or body</description>
 
     <parent>
         <groupId>io.gravitee</groupId>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2187
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.6.1-update-description-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-url-rewriting/1.6.1-update-description-SNAPSHOT/gravitee-policy-url-rewriting-1.6.1-update-description-SNAPSHOT.zip)
  <!-- Version placeholder end -->
